### PR TITLE
Task/create unique tf frames

### DIFF
--- a/realsense_ros/include/realsense/rs_base.hpp
+++ b/realsense_ros/include/realsense/rs_base.hpp
@@ -81,6 +81,8 @@ protected:
   Result changeResolution(const stream_index_pair & stream, const rclcpp::Parameter & param);
   Result changeFPS(const stream_index_pair & stream, const rclcpp::Parameter & param);
 
+  std::string replaceCameraName(const std::string& inString);
+
   typedef struct VideoStreamInfo
   {
     //rs2_format format;
@@ -100,6 +102,8 @@ protected:
   rs2::pipeline pipeline_;
   rs2::config cfg_;
   std::string base_frame_id_;
+  std::string default_camera_name_;
+  std::string camera_name_;
   rs2::frame_queue frame_data;
   std::thread work_thread_;
   std::shared_ptr<tf2_ros::StaticTransformBroadcaster> static_tf_broadcaster_;

--- a/realsense_ros/include/realsense/rs_d435.hpp
+++ b/realsense_ros/include/realsense/rs_d435.hpp
@@ -48,6 +48,27 @@ protected:
   rs2::pointcloud pc_;
   rs2::points points_;
 
+  // Frame names
+  std::string depth_frame_id_;
+  std::string infra1_frame_id_;
+  std::string infra2_frame_id_;
+  std::string color_frame_id_;
+  std::string fisheye1_frame_id_;
+  std::string fisheye2_frame_id_;
+  std::string pose_frame_id_;
+  
+  std::string depth_optical_frame_id_;
+  std::string infra1_optical_frame_id_;
+  std::string infra2_optical_frame_id_;
+  std::string color_optical_frame_id_;
+  std::string fisheye1_optical_frame_id_;
+  std::string fisheye2_optical_frame_id_;
+  std::string accel_optical_frame_id_;
+  std::string gyro_optical_frame_id_;
+  std::string pose_optical_frame_id_;
+  
+  std::string aligned_depth_to_color_frame_id_;
+
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr aligned_depth_image_pub_;
   rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr aligned_depth_info_pub_;
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pointcloud_pub_;

--- a/realsense_ros/src/rs_base.cpp
+++ b/realsense_ros/src/rs_base.cpp
@@ -22,7 +22,8 @@ using namespace std::chrono_literals;
 RealSenseBase::RealSenseBase(rs2::context ctx, rs2::device dev, rclcpp::Node & node)
 : node_(node),
   ctx_(ctx),
-  dev_(dev)
+  dev_(dev),
+  default_camera_name_("camera")
 {
   // Publish static transforms
   if (node_.has_parameter("base_frame_id")) {
@@ -31,7 +32,6 @@ RealSenseBase::RealSenseBase(rs2::context ctx, rs2::device dev, rclcpp::Node & n
     base_frame_id_ = node_.declare_parameter("base_frame_id", DEFAULT_BASE_FRAME_ID);
   }
   // Assign camera name based on input base frame
-  default_camera_name_ = "camera";
   std::string underscore = "_";
   // Get index of underscore after camera name ex: camera_link or realsense_link
   auto ind_underscore = base_frame_id_.find(underscore);

--- a/realsense_ros/src/rs_d435.cpp
+++ b/realsense_ros/src/rs_d435.cpp
@@ -54,6 +54,28 @@ RealSenseD435::RealSenseD435(rs2::context ctx, rs2::device dev, rclcpp::Node & n
   } else {
     dense_pc_ = node_.declare_parameter("dense_pointcloud", DENSE_PC);
   }
+
+  // Initialize frame names
+  depth_frame_id_ = replaceCameraName(DEFAULT_DEPTH_FRAME_ID);
+  infra1_frame_id_ = replaceCameraName(DEFAULT_INFRA1_FRAME_ID);
+  infra2_frame_id_ = replaceCameraName(DEFAULT_INFRA2_FRAME_ID);
+  color_frame_id_ = replaceCameraName(DEFAULT_COLOR_FRAME_ID);
+  fisheye1_frame_id_ = replaceCameraName(DEFAULT_FISHEYE1_FRAME_ID);
+  fisheye2_frame_id_ = replaceCameraName(DEFAULT_FISHEYE2_FRAME_ID);
+  pose_frame_id_ = replaceCameraName(DEFAULT_FISHEYE2_FRAME_ID);
+
+  depth_optical_frame_id_ = replaceCameraName(DEFAULT_POSE_FRAME_ID);
+  infra1_optical_frame_id_ = replaceCameraName(DEFAULT_INFRA1_OPTICAL_FRAME_ID);
+  infra2_optical_frame_id_ = replaceCameraName(DEFAULT_INFRA2_OPTICAL_FRAME_ID);
+  color_optical_frame_id_ = replaceCameraName(DEFAULT_COLOR_OPTICAL_FRAME_ID);
+  fisheye1_optical_frame_id_ = replaceCameraName(DEFAULT_FISHEYE1_OPTICAL_FRAME_ID);
+  fisheye2_optical_frame_id_ = replaceCameraName(DEFAULT_FISHEYE2_OPTICAL_FRAME_ID);
+  accel_optical_frame_id_ = replaceCameraName(DEFAULT_ACCEL_OPTICAL_FRAME_ID);
+  gyro_optical_frame_id_ = replaceCameraName(DEFAULT_GYRO_OPTICAL_FRAME_ID);
+  pose_optical_frame_id_ = replaceCameraName(DEFAULT_POSE_OPTICAL_FRAME_ID);
+  
+  aligned_depth_to_color_frame_id_ = replaceCameraName(DEFAULT_ALIGNED_DEPTH_TO_COLOR_FRAME_ID);
+
   initialized_ = true;
 }
 
@@ -174,7 +196,7 @@ void RealSenseD435::publishAlignedDepthTopic(const rs2::frame & frame, const rcl
     //debug
     //RCLCPP_INFO(node_.get_logger(), "timestamp: %f, address: %p", t.seconds(), reinterpret_cast<std::uintptr_t>(img.get()));
     //
-    img->header.frame_id = replaceCameraName(DEFAULT_ALIGNED_DEPTH_TO_COLOR_FRAME_ID);  //diff with publishTopics
+    img->header.frame_id = aligned_depth_to_color_frame_id_;  //diff with publishTopics
     img->header.stamp = time;
     aligned_depth_image_pub_->publish(*img);  //diff
   } else {
@@ -184,7 +206,7 @@ void RealSenseD435::publishAlignedDepthTopic(const rs2::frame & frame, const rcl
     //debug
     //RCLCPP_INFO(node_.get_logger(), "timestamp: %f, address: %p", t.seconds(), reinterpret_cast<std::uintptr_t>(img.get()));
     //
-    img->header.frame_id = replaceCameraName(DEFAULT_ALIGNED_DEPTH_TO_COLOR_FRAME_ID);
+    img->header.frame_id = aligned_depth_to_color_frame_id_;
     img->header.stamp = time;
     aligned_depth_image_pub_->publish(std::move(img));
   }
@@ -214,7 +236,7 @@ void RealSenseD435::publishSparsePointCloud(const rs2::points & points, const rs
     //RCLCPP_INFO(node_.get_logger(), "timestamp: %f, address: %p", t.seconds(), reinterpret_cast<std::uintptr_t>(pc_msg.get()));
     //
     pc_msg->header.stamp = time;
-    pc_msg->header.frame_id = replaceCameraName(DEFAULT_COLOR_OPTICAL_FRAME_ID);
+    pc_msg->header.frame_id = color_optical_frame_id_;
     pc_msg->width = valid_indices.size();
     pc_msg->height = 1;
     pc_msg->point_step = 3 * sizeof(float) + 3 * sizeof(uint8_t);
@@ -265,7 +287,7 @@ void RealSenseD435::publishSparsePointCloud(const rs2::points & points, const rs
     //RCLCPP_INFO(node_.get_logger(), "timestamp: %f, address: %p", t.seconds(), reinterpret_cast<std::uintptr_t>(pc_msg.get()));
     //
     pc_msg->header.stamp = time;
-    pc_msg->header.frame_id = replaceCameraName(DEFAULT_COLOR_OPTICAL_FRAME_ID);
+    pc_msg->header.frame_id = color_optical_frame_id_;
     pc_msg->width = valid_indices.size();
     pc_msg->height = 1;
     pc_msg->point_step = 3 * sizeof(float) + 3 * sizeof(uint8_t);
@@ -322,7 +344,7 @@ void RealSenseD435::publishDensePointCloud(const rs2::points & points, const rs2
     //RCLCPP_INFO(node_.get_logger(), "timestamp: %f, address: %p", t.seconds(), reinterpret_cast<std::uintptr_t>(pc_msg.get()));
     //
     pc_msg->header.stamp = time;
-    pc_msg->header.frame_id = replaceCameraName(DEFAULT_COLOR_OPTICAL_FRAME_ID);
+    pc_msg->header.frame_id = color_optical_frame_id_;
     pc_msg->width = color_frame.get_width();
     pc_msg->height = color_frame.get_height();
     pc_msg->point_step = 3 * sizeof(float) + 3 * sizeof(uint8_t);
@@ -364,7 +386,7 @@ void RealSenseD435::publishDensePointCloud(const rs2::points & points, const rs2
     //RCLCPP_INFO(node_.get_logger(), "timestamp: %f, address: %p", t.seconds(), reinterpret_cast<std::uintptr_t>(pc_msg.get()));
     //
     pc_msg->header.stamp = time;
-    pc_msg->header.frame_id = replaceCameraName(DEFAULT_COLOR_OPTICAL_FRAME_ID);
+    pc_msg->header.frame_id = color_optical_frame_id_;
     pc_msg->width = color_frame.get_width();
     pc_msg->height =  color_frame.get_height();
     pc_msg->point_step = 3 * sizeof(float) + 3 * sizeof(uint8_t);

--- a/realsense_ros/src/rs_d435.cpp
+++ b/realsense_ros/src/rs_d435.cpp
@@ -172,9 +172,9 @@ void RealSenseD435::publishAlignedDepthTopic(const rs2::frame & frame, const rcl
     sensor_msgs::msg::Image::SharedPtr img;
     img = cv_bridge::CvImage(std_msgs::msg::Header(), MSG_ENCODING.at(type), cv_image).toImageMsg();
     //debug
-    //RCLCPP_INFO(node_->get_logger(), "timestamp: %f, address: %p", t.seconds(), reinterpret_cast<std::uintptr_t>(img.get()));
+    //RCLCPP_INFO(node_.get_logger(), "timestamp: %f, address: %p", t.seconds(), reinterpret_cast<std::uintptr_t>(img.get()));
     //
-    img->header.frame_id = DEFAULT_ALIGNED_DEPTH_TO_COLOR_FRAME_ID;  //diff with publishTopics
+    img->header.frame_id = replaceCameraName(DEFAULT_ALIGNED_DEPTH_TO_COLOR_FRAME_ID);  //diff with publishTopics
     img->header.stamp = time;
     aligned_depth_image_pub_->publish(*img);  //diff
   } else {
@@ -182,9 +182,9 @@ void RealSenseD435::publishAlignedDepthTopic(const rs2::frame & frame, const rcl
     img = std::make_unique<sensor_msgs::msg::Image>();
     cv_bridge::CvImage(std_msgs::msg::Header(), sensor_msgs::image_encodings::RGB8, cv_image).toImageMsg(*img);
     //debug
-    //RCLCPP_INFO(node_->get_logger(), "timestamp: %f, address: %p", t.seconds(), reinterpret_cast<std::uintptr_t>(img.get()));
+    //RCLCPP_INFO(node_.get_logger(), "timestamp: %f, address: %p", t.seconds(), reinterpret_cast<std::uintptr_t>(img.get()));
     //
-    img->header.frame_id = DEFAULT_ALIGNED_DEPTH_TO_COLOR_FRAME_ID;
+    img->header.frame_id = replaceCameraName(DEFAULT_ALIGNED_DEPTH_TO_COLOR_FRAME_ID);
     img->header.stamp = time;
     aligned_depth_image_pub_->publish(std::move(img));
   }
@@ -211,10 +211,10 @@ void RealSenseD435::publishSparsePointCloud(const rs2::points & points, const rs
   if (!node_.get_node_options().use_intra_process_comms()) {
     sensor_msgs::msg::PointCloud2::SharedPtr pc_msg = std::make_shared<sensor_msgs::msg::PointCloud2>();
     //debug
-    //RCLCPP_INFO(node_->get_logger(), "timestamp: %f, address: %p", t.seconds(), reinterpret_cast<std::uintptr_t>(pc_msg.get()));
+    //RCLCPP_INFO(node_.get_logger(), "timestamp: %f, address: %p", t.seconds(), reinterpret_cast<std::uintptr_t>(pc_msg.get()));
     //
     pc_msg->header.stamp = time;
-    pc_msg->header.frame_id = DEFAULT_COLOR_OPTICAL_FRAME_ID;
+    pc_msg->header.frame_id = replaceCameraName(DEFAULT_COLOR_OPTICAL_FRAME_ID);
     pc_msg->width = valid_indices.size();
     pc_msg->height = 1;
     pc_msg->point_step = 3 * sizeof(float) + 3 * sizeof(uint8_t);
@@ -262,10 +262,10 @@ void RealSenseD435::publishSparsePointCloud(const rs2::points & points, const rs
   } else {
     sensor_msgs::msg::PointCloud2::UniquePtr pc_msg = std::make_unique<sensor_msgs::msg::PointCloud2>();
     //debug
-    //RCLCPP_INFO(node_->get_logger(), "timestamp: %f, address: %p", t.seconds(), reinterpret_cast<std::uintptr_t>(pc_msg.get()));
+    //RCLCPP_INFO(node_.get_logger(), "timestamp: %f, address: %p", t.seconds(), reinterpret_cast<std::uintptr_t>(pc_msg.get()));
     //
     pc_msg->header.stamp = time;
-    pc_msg->header.frame_id = DEFAULT_COLOR_OPTICAL_FRAME_ID;
+    pc_msg->header.frame_id = replaceCameraName(DEFAULT_COLOR_OPTICAL_FRAME_ID);
     pc_msg->width = valid_indices.size();
     pc_msg->height = 1;
     pc_msg->point_step = 3 * sizeof(float) + 3 * sizeof(uint8_t);
@@ -319,10 +319,10 @@ void RealSenseD435::publishDensePointCloud(const rs2::points & points, const rs2
   if (!node_.get_node_options().use_intra_process_comms()) {
     sensor_msgs::msg::PointCloud2::SharedPtr pc_msg = std::make_shared<sensor_msgs::msg::PointCloud2>();
     //debug
-    //RCLCPP_INFO(node_->get_logger(), "timestamp: %f, address: %p", t.seconds(), reinterpret_cast<std::uintptr_t>(pc_msg.get()));
+    //RCLCPP_INFO(node_.get_logger(), "timestamp: %f, address: %p", t.seconds(), reinterpret_cast<std::uintptr_t>(pc_msg.get()));
     //
     pc_msg->header.stamp = time;
-    pc_msg->header.frame_id = DEFAULT_COLOR_OPTICAL_FRAME_ID;
+    pc_msg->header.frame_id = replaceCameraName(DEFAULT_COLOR_OPTICAL_FRAME_ID);
     pc_msg->width = color_frame.get_width();
     pc_msg->height = color_frame.get_height();
     pc_msg->point_step = 3 * sizeof(float) + 3 * sizeof(uint8_t);
@@ -361,10 +361,10 @@ void RealSenseD435::publishDensePointCloud(const rs2::points & points, const rs2
   } else {
     sensor_msgs::msg::PointCloud2::UniquePtr pc_msg = std::make_unique<sensor_msgs::msg::PointCloud2>();
     //debug
-    //RCLCPP_INFO(node_->get_logger(), "timestamp: %f, address: %p", t.seconds(), reinterpret_cast<std::uintptr_t>(pc_msg.get()));
+    //RCLCPP_INFO(node_.get_logger(), "timestamp: %f, address: %p", t.seconds(), reinterpret_cast<std::uintptr_t>(pc_msg.get()));
     //
     pc_msg->header.stamp = time;
-    pc_msg->header.frame_id = DEFAULT_COLOR_OPTICAL_FRAME_ID;
+    pc_msg->header.frame_id = replaceCameraName(DEFAULT_COLOR_OPTICAL_FRAME_ID);
     pc_msg->width = color_frame.get_width();
     pc_msg->height =  color_frame.get_height();
     pc_msg->point_step = 3 * sizeof(float) + 3 * sizeof(uint8_t);


### PR DESCRIPTION
Manipulated camera frames to have the prefix of the base frame instead of being hardcoded to `"camera"`
For example, if the user specifies the base link as `"realsense1_link"`, the derived frames will be `"realsense1_depth_frame"`, `"realsense1_color_frame"`, etc. instead of `"camera_depth_frame"`, `"camera_color_frame"`, etc.

Because all derived frames were hardcoded to have the prefix `"camera"` the running of multiple cameras with unique TF frames was not supported.