### PR TITLE
Add option to use hole filling filter on depth data

### DIFF
--- a/realsense_ros/include/realsense/rs_constants.hpp
+++ b/realsense_ros/include/realsense/rs_constants.hpp
@@ -39,6 +39,7 @@ namespace realsense
   const bool ALIGN_DEPTH = true;
   const bool ENABLE_POINTCLOUD = true;
   const bool DENSE_PC = true;
+  const bool ENABLE_HOLE_FILLING = false;
   const bool DEFAULT_ENABLE_STREAM = true;
 
   const std::vector<int> DEFAULT_IMAGE_RESOLUTION = {640, 480};

--- a/realsense_ros/include/realsense/rs_d435.hpp
+++ b/realsense_ros/include/realsense/rs_d435.hpp
@@ -44,6 +44,8 @@ protected:
   bool enable_pointcloud_;
   bool dense_pc_;
   bool initialized_ = false;
+  bool enable_hole_filling_;
+  rs2::hole_filling_filter hole_filling_filter_;
   rs2::align align_to_color_ = rs2::align(RS2_STREAM_COLOR);
   rs2::pointcloud pc_;
   rs2::points points_;


### PR DESCRIPTION
The realsense assigning zeroes to unknown depth values was identified as a potential culprit for objects being misdetected.  The SDK provides a hole filling filter to fill in these regions from known data surrounding them.  This provides a parameter to enable hole filling so we the theory can be tested.