### PR TITLE
Issue/two same cameras launch

### DIFF
--- a/realsense_ros/src/rs_base.cpp
+++ b/realsense_ros/src/rs_base.cpp
@@ -31,8 +31,11 @@ RealSenseBase::RealSenseBase(rs2::context ctx, rs2::device dev, rclcpp::Node & n
   } else {
     base_frame_id_ = node_.declare_parameter("base_frame_id", DEFAULT_BASE_FRAME_ID);
   }
+  // Patch for two camera launch problem: 
+  // https://github.com/intel/ros2_intel_realsense/pull/115/commits/1d39aed6b81740b5820879beaf284f8acf8d53c0
   auto sn = dev_.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
   cfg_.enable_device(sn);
+  
   // Assign camera name based on input base frame
   std::string underscore = "_";
   // Get index of underscore after camera name ex: camera_link or realsense_link

--- a/realsense_ros/src/rs_base.cpp
+++ b/realsense_ros/src/rs_base.cpp
@@ -31,6 +31,8 @@ RealSenseBase::RealSenseBase(rs2::context ctx, rs2::device dev, rclcpp::Node & n
   } else {
     base_frame_id_ = node_.declare_parameter("base_frame_id", DEFAULT_BASE_FRAME_ID);
   }
+  auto sn = dev_.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
+  cfg_.enable_device(sn);
   // Assign camera name based on input base frame
   std::string underscore = "_";
   // Get index of underscore after camera name ex: camera_link or realsense_link


### PR DESCRIPTION
Fixed an issue where two realsense cameras of the same model could not be launched together.