### PR TITLE
fix for serial numbers with leading zero

### DIFF
--- a/realsense_ros/src/rs_factory.cpp
+++ b/realsense_ros/src/rs_factory.cpp
@@ -40,13 +40,11 @@ RealSenseNodeFactory::~RealSenseNodeFactory()
 
 void RealSenseNodeFactory::init()
 {
-  auto param_desc = rcl_interfaces::msg::ParameterDescriptor();
-  param_desc.read_only = true;
-  auto param_value = declare_parameter("serial_no");
-  if (param_value.get_type() == rclcpp::PARAMETER_NOT_SET) {
+  declare_parameter("serial_no", "");
+  get_parameter("serial_no", serial_no_);
+
+  if (serial_no_.empty()) {
     RCLCPP_INFO(this->get_logger(), "Device's serial number is not set, enabling the default device!");
-  } else {
-    serial_no_ = std::to_string(param_value.get<rclcpp::PARAMETER_INTEGER>());
   }
   try {
     query_thread_ = std::thread([=]()


### PR DESCRIPTION
This will force serial numbers to be string parameters. Serial numbers should be string escaped in python launch files as so:
camera1_serial_no = LaunchConfiguration('serial_no', default='"036522070521"')
camera2_serial_no = LaunchConfiguration('serial_no', default='"032622071010"')

This will force serial numbers to be interpreted as strings.